### PR TITLE
[SB-35] Show categories in user app

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,6 @@
+class CategoriesController < ApplicationController
+  def index
+    @categories = Category.all.includes(services: :wallet)
+    @wallet = params[:wallet_reciepent]
+  end
+end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,20 @@
+<div class="accordion accordion-flush" id="accordionFlushExample">
+  <% @categories.each do |category| %>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="flush-heading<%= category.id %>">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse<%= category.id %>" aria-expanded="false" aria-controls="flush-collapse<%= category.id %>">
+          <%= category.name  %>
+        </button>
+      </h2>
+      <div id="flush-collapse<%= category.id %>" class="accordion-collapse collapse" aria-labelledby="flush-heading<%= category.id %>" data-bs-parent="#accordionFlushExample">
+        <div class="accordion-body">
+          <ul>
+            <% category.services.each do |service| %>
+              <li><%= link_to service.name, new_transactions_path({:wallet_reciepent => service.wallet.wallet_number}) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -5,7 +5,7 @@
   <br/>
   <%= f.text_field :sum, :placeholder => t('transaction.write_sum'), class: "form-control" %>
   <br/>
-  <%= f.text_field :wallet_reciepent, :placeholder => t('transaction.wallet_reciepent'), class: "form-control" %>
+  <%= f.text_field :wallet_reciepent, :value => params[:wallet_reciepent] || @transaction.wallet, :placeholder => t('transaction.wallet_reciepent'), class: "form-control" %>
   <%=t('transaction.comission')%> <%= f.label @transaction.fee, "#{@transaction.fee}", class: "form-label" %>
     <br/>
     <%= f.submit t('transaction.make_transfer'), class: "btn btn-primary" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -140,6 +140,7 @@
 
           <div class='mt-3 ml-3'>
               <%= link_to t('users.make_transfer'), new_transactions_path, class: "btn btn-info" %>
+               <%= link_to t('services.make_transfer'), categories_path, class: "btn btn-info" %>
               <a class='ml-1'>
                 <%= link_to t('users.trasfers_history'), transactions_path, class: "btn btn-success" %>
               </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,3 +101,7 @@ en:
     transaction_amount: "Transaction amount:"
     transaction_comission: "Transaction comission:"
     transaction_date: "Transaction date:"
+  services:
+    make_transfer: "Pay for service"
+
+

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -69,4 +69,5 @@ ru:
     transaction_amount: "Сумма транзакции:"
     transaction_comission: "Комиссия:"
     transaction_date: "Дата транзакции:"
-    
+  services:
+    make_transfer: "Оплата сервиса"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resources :wallets
     resource :users
     resource :transactions
+    resources :categories
     
     get 'home/index'
     get '/about', to: 'home#about'


### PR DESCRIPTION
https://trello.com/c/bFfyEY9a/69-sb-35-show-categories-in-user-app

When user pushes the button "Pay for service"
![Снимок экрана 2021-07-12 в 23 01 34](https://user-images.githubusercontent.com/77982821/125348610-1e086200-e365-11eb-8fef-e348c0b1d8eb.png)

He gets on the on the Categories page with collapsible/expandable accordion menu with links to pay for Services
![Снимок экрана 2021-07-12 в 23 02 38](https://user-images.githubusercontent.com/77982821/125348736-455f2f00-e365-11eb-997a-b9c9342758d2.png)

When user pushes one of the Services links he gets on the new transactions page with pre-populated recipient wallet number (refer to services wallet)
![Снимок экрана 2021-07-12 в 23 07 20](https://user-images.githubusercontent.com/77982821/125349214-ed74f800-e365-11eb-90e1-95df4896b2a8.png)

